### PR TITLE
Fix harvest pagination dag

### DIFF
--- a/dgv/harvester/DAG.py
+++ b/dgv/harvester/DAG.py
@@ -20,7 +20,7 @@ def get_pending_harvester_from_api(ti):
     r = requests.get(
         "https://www.data.gouv.fr/api/1/harvest/sources/?page=" + str(page)
     )
-    maxpage = int(r.json()["total"] / r.json()["page_size"] + 1)
+    maxpage = int(r.json()["total"] / r.json()["page_size"]) + 1
     arr = []
     cpt = 0
     page = 0
@@ -29,6 +29,7 @@ def get_pending_harvester_from_api(ti):
             "https://www.data.gouv.fr/api/1/harvest/sources/?page=" + str(page + 1)
         )
         print("https://www.data.gouv.fr/api/1/harvest/sources/?page=" + str(page + 1))
+        r.raise_for_status()
         for d in r.json()["data"]:
             cpt = cpt + 1
             if d["validation"]["state"] == "pending":


### PR DESCRIPTION
Job is currently failing due to wrong pagination.

maxpage should probably be (total / page_size) + 1

We could also have used this incredible util function by @Pierlou: https://github.com/etalab/datagouvfr_data_pipelines/blob/79e459da4f26055915d3bd3461e3675823d2ce23/utils/datagouv.py#L439