### PR TITLE
metrics: Add total views that sum all for all objects

### DIFF
--- a/dgv/metrics/sql/create_tables.sql
+++ b/dgv/metrics/sql/create_tables.sql
@@ -182,6 +182,47 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS airflow.site AS
     ON datasets.metric_month = reuses.metric_month
 ;
 
+-- Sum tables
+CREATE MATERIALIZED VIEW IF NOT EXISTS airflow.datasets_total AS
+    SELECT
+        dataset_id,
+        sum(nb_visit) as visit,
+        sum(nb_outlink) as outlink,
+        sum(resource_nb_visit) as visit_resource
+    FROM airflow.metrics_datasets
+    GROUP BY dataset_id
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS airflow.reuses_total AS
+    SELECT
+        reuse_id,
+        sum(nb_visit) as visit,
+        sum(nb_outlink) as outlink
+    FROM airflow.metrics_reuses
+    GROUP BY reuse_id
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS airflow.organizations_total AS
+    SELECT
+        organization_id,
+        sum(dataset_nb_visit) as visit_dataset,
+        sum(resource_nb_visit) as visit_resource,
+        sum(reuse_nb_visit) as visit_reuse,
+        sum(nb_outlink) as outlink
+    FROM airflow.metrics_organizations
+    GROUP BY organization_id
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS airflow.resources_total AS
+    SELECT
+        resource_id,
+        dataset_id,
+        sum(nb_visit) as visit_resource
+    FROM airflow.visits_resources
+    GROUP BY resource_id, dataset_id
+;
+
+
 CREATE INDEX IF NOT EXISTS visits_datasets_dataset_id ON airflow.visits_datasets USING btree (dataset_id);
 CREATE INDEX IF NOT EXISTS visits_datasets_date_metric ON airflow.visits_datasets USING btree (date_metric);
 CREATE INDEX IF NOT EXISTS visits_datasets_organization_id ON airflow.visits_datasets USING btree (organization_id);

--- a/dgv/metrics/sql/refresh_materialized_views.sql
+++ b/dgv/metrics/sql/refresh_materialized_views.sql
@@ -6,3 +6,7 @@ REFRESH MATERIALIZED VIEW airflow.reuses;
 REFRESH MATERIALIZED VIEW airflow.organizations;
 REFRESH MATERIALIZED VIEW airflow.resources;
 REFRESH MATERIALIZED VIEW airflow.site;
+REFRESH MATERIALIZED VIEW airflow.datasets_total;
+REFRESH MATERIALIZED VIEW airflow.reuses_total;
+REFRESH MATERIALIZED VIEW airflow.organizations_total;
+REFRESH MATERIALIZED VIEW airflow.resources_total;


### PR DESCRIPTION
Creating dedicated views is useful to paginate on objects metrics.
Having daily or monthly views would require the client to implement an aggregation logic, which would be way more tricky.

We're aggregating metrics based on `metrics_*` views, but we could have used others.

See example usage in udata-metrics aggregation, introduced in https://github.com/opendatateam/udata-metrics/pull/8.

Open for wording suggestions :)