### PR TITLE
[data_processing][rne]Download RNE stock files using ftp instead of https

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,8 +50,10 @@ SECRET_INSEE_BEARER = Variable.get("SECRET_INSEE_BEARER", "")
 SECRET_INPI_USER = Variable.get("SECRET_INPI_USER", "")
 SECRET_INPI_PASSWORD = Variable.get("SECRET_INPI_PASSWORD", "")
 
+
 # RNE
 AUTH_RNE = json.loads(Variable.get("AUTH_RNE", []))
+RNE_FTP_URL = Variable.get("RNE_FTP_URL", "")
 
 # Twitter
 TWITTER_CONSUMER_KEY = Variable.get("TWITTER_CONSUMER_KEY", "")

--- a/config.py
+++ b/config.py
@@ -50,7 +50,6 @@ SECRET_INSEE_BEARER = Variable.get("SECRET_INSEE_BEARER", "")
 SECRET_INPI_USER = Variable.get("SECRET_INPI_USER", "")
 SECRET_INPI_PASSWORD = Variable.get("SECRET_INPI_PASSWORD", "")
 
-
 # RNE
 AUTH_RNE = json.loads(Variable.get("AUTH_RNE", []))
 RNE_FTP_URL = Variable.get("RNE_FTP_URL", "")

--- a/data_processing/rne/stock/DAG.py
+++ b/data_processing/rne/stock/DAG.py
@@ -2,9 +2,10 @@ from airflow.models import DAG
 from datetime import timedelta, datetime
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
+from datagouvfr_data_pipelines.config import AIRFLOW_DAG_HOME, RNE_FTP_URL
 from datagouvfr_data_pipelines.data_processing.rne.stock.task_functions import (
     TMP_FOLDER,
-    get_rne_stock,
+    DAG_FOLDER,
     unzip_files,
     send_extracted_files_to_minio,
     send_notification_mattermost,
@@ -25,8 +26,12 @@ with DAG(
         bash_command=f"rm -rf {TMP_FOLDER} && mkdir -p {TMP_FOLDER}",
     )
 
-    get_rne_latest_stock = PythonOperator(
-        task_id="get_latest_stock", python_callable=get_rne_stock
+    get_rne_latest_stock = BashOperator(
+        task_id="get_latest_stock",
+        bash_command=(
+            f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}rne/stock/scripts/stock.sh "
+            f"{TMP_FOLDER} {RNE_FTP_URL} "
+        ),
     )
 
     unzip_files = PythonOperator(task_id="unzip_files", python_callable=unzip_files)

--- a/data_processing/rne/stock/scripts/stock.sh
+++ b/data_processing/rne/stock/scripts/stock.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Check if the required arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <TMP_FOLDER> <FTP_URL>"
+    exit 1
+fi
+
+# Assign arguments to variables
+TMP_FOLDER="$1"
+FTP_URL="$2"
+
+# Use lftp to connect to the FTP server and download the file
+lftp -e "get '$FTP_URL' -o '$TMP_FOLDER'; quit"
+
+# Check if the FTP operation was successful
+if [ $? -eq 0 ]; then
+    echo "File downloaded successfully to $TMP_FOLDER."
+else
+    echo "FTP download failed."
+    exit 1
+fi

--- a/data_processing/rne/stock/scripts/stock.sh
+++ b/data_processing/rne/stock/scripts/stock.sh
@@ -11,7 +11,7 @@ TMP_FOLDER="$1"
 FTP_URL="$2"
 
 # Use lftp to connect to the FTP server and download the file
-lftp -e "get '$FTP_URL' -o '$TMP_FOLDER'; quit"
+lftp -e "get '$FTP_URL' -o '$TMP_FOLDER/stock_rne.zip'; quit"
 
 # Check if the FTP operation was successful
 if [ $? -eq 0 ]; then

--- a/data_processing/rne/stock/task_functions.py
+++ b/data_processing/rne/stock/task_functions.py
@@ -1,4 +1,3 @@
-from datagouvfr_data_pipelines.utils.download import download_files
 import os
 import zipfile
 from datagouvfr_data_pipelines.utils.mattermost import send_message
@@ -15,20 +14,8 @@ from datagouvfr_data_pipelines.config import (
 DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
 TMP_FOLDER = f"{AIRFLOW_DAG_TMP}rne/stock/"
 DATADIR = f"{TMP_FOLDER}data"
-ZIP_FILE_PATH = f"{TMP_FOLDER}rne.zip"
+ZIP_FILE_PATH = f"{TMP_FOLDER}stock_rne.zip"
 EXTRACTED_FILES_PATH = f"{TMP_FOLDER}extracted/"
-
-
-def get_rne_stock():
-    download_files(
-        [
-            {
-                "url": "https://www.inpi.fr/sites/default/files/rne/stock_rne.zip",
-                "dest_path": f"{TMP_FOLDER}",
-                "dest_name": "rne.zip",
-            },
-        ]
-    )
 
 
 def unzip_files():


### PR DESCRIPTION
INPI changed where RNE stock files are stored. They are no longer accessible from a web page but can only be downloaded via ftp.